### PR TITLE
Integration with @angular/forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Cloudflare Turnstile Component for Angular
 
 ## ngx-turnstile
@@ -55,9 +54,11 @@ export class MyApp {
 ```
 
 ## Usage with @angular/forms
-Import both NgxTurnstileModule and NgxTurnstileFormsModule modules in your app module. 
+
+Import both NgxTurnstileModule and NgxTurnstileFormsModule modules in your app module.
+
 ```typescript
-import { NgxTurnstileModule, NgxTurnstileFormsModule  } from "ngx-turnstile";
+import { NgxTurnstileModule, NgxTurnstileFormsModule } from "ngx-turnstile";
 ```
 
 Then import either FormsModule or ReactiveFormsModule from @angular/forms depending on the type of form you want to use.
@@ -65,20 +66,22 @@ Then import either FormsModule or ReactiveFormsModule from @angular/forms depend
 You can then use the ngModel, formControl or formControlName directives on the component depending on which module you imported from @angular/forms.
 
 ### Reactive Form Example
+
 ```html
-<ngx-turnstile 
-[siteKey]="siteKey" 
-theme="auto"
-[formControl]="tokenControl"
+<ngx-turnstile
+  [siteKey]="siteKey"
+  theme="auto"
+  [formControl]="tokenControl"
 ></ngx-turnstile>
 ```
 
 ### Template Driven Form Example
+
 ```html
 <ngx-turnstile
-[siteKey]="siteKey"
-theme="light"
-[(ngModel)]="token"
+  [siteKey]="siteKey"
+  theme="light"
+  [(ngModel)]="token"
 ></ngx-turnstile>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Cloudflare Turnstile Component for Angular
 
 ## ngx-turnstile
@@ -15,18 +16,18 @@ npm install ngx-turnstile --save
 
 ## Quickstart
 
-To start, import the TurnstileModule in your app module.
+To start, import the NgxTurnstileModule in your app module.
 
 ```typescript
 // app.module.ts
-import { TurnstileModule } from "ngx-turnstile";
+import { NgxTurnstileModule } from "ngx-turnstile";
 import { BrowserModule } from "@angular/platform-browser";
 import { MyApp } from "./app.component.ts";
 
 @NgModule({
   bootstrap: [MyApp],
   declarations: [MyApp],
-  imports: [BrowserModule, TurnstileModule],
+  imports: [BrowserModule, NgxTurnstileModule],
 })
 export class MyAppModule {}
 ```
@@ -52,6 +53,36 @@ export class MyApp {
   }
 }
 ```
+
+## Usage with @angular/forms
+Import both NgxTurnstileModule and NgxTurnstileFormsModule modules in your app module. 
+```typescript
+import { NgxTurnstileModule, NgxTurnstileFormsModule  } from "ngx-turnstile";
+```
+
+Then import either FormsModule or ReactiveFormsModule from @angular/forms depending on the type of form you want to use.
+
+You can then use the ngModel, formControl or formControlName directives on the component depending on which module you imported from @angular/forms.
+
+### Reactive Form Example
+```html
+<ngx-turnstile 
+[siteKey]="siteKey" 
+theme="auto"
+[formControl]="tokenControl"
+></ngx-turnstile>
+```
+
+### Template Driven Form Example
+```html
+<ngx-turnstile
+[siteKey]="siteKey"
+theme="light"
+[(ngModel)]="token"
+></ngx-turnstile>
+```
+
+The component is read-only, meaning that you should not update the control with a custom value. Updating the control value will reset the component
 
 ## API
 

--- a/projects/ngx-turnstile-demo/src/app/app.component.ts
+++ b/projects/ngx-turnstile-demo/src/app/app.component.ts
@@ -1,10 +1,24 @@
-import { Component } from '@angular/core';
-import { NgxTurnstileModule } from 'ngx-turnstile';
+import { Component, OnInit } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-root',
   styles: [
     `
+      .container {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 2em;
+      }
+      .example-container {
+        display: flex;
+        flex-direction: column;
+        min-width: 19em;
+        gap: 0.5em;
+      }
+
       .form-signin {
         width: 100%;
         max-width: 330px;
@@ -31,11 +45,36 @@ import { NgxTurnstileModule } from 'ngx-turnstile';
         border-top-left-radius: 0;
         border-top-right-radius: 0;
       }
+
+      .route-active {
+        color: black;
+        font-size: 20px;
+        transition: font-size 1s;
+      }
     `,
   ],
   standalone: true,
   template: `
     <div class="container pt-5">
+      <div class="example-container">
+        <h5>Examples:</h5>
+        <a
+          routerLink=""
+          [routerLinkActive]="['route-active']"
+          [routerLinkActiveOptions]="{ exact: true }"
+          >Event Binding Example</a
+        >
+        <a
+          routerLink="/reactive-form-example"
+          [routerLinkActive]="['route-active']"
+          >Reactive Form Example</a
+        >
+        <a
+          routerLink="/template-driven-form-example"
+          [routerLinkActive]="['route-active']"
+          >Template Driven Form Example</a
+        >
+      </div>
       <main class="form-signin">
         <form action="https://demo.turnstile.workers.dev/handler" method="POST">
           <h2 class="h3 mb-3 fw-normal">Turnstile &dash; Dummy Login Demo</h2>
@@ -56,13 +95,9 @@ import { NgxTurnstileModule } from 'ngx-turnstile';
             <label for="pass">Password (dummy)</label>
           </div>
 
-          <div class="checkbox mb-3">
+          <div class="checkbox">
             <!-- The following line controls and configures the Turnstile widget. -->
-            <ngx-turnstile
-              [siteKey]="siteKey"
-              theme="light"
-              (resolved)="onResolved($event)"
-            ></ngx-turnstile>
+            <router-outlet></router-outlet>
             <!-- end. -->
           </div>
           <button class="w-100 btn btn-lg btn-primary" type="submit">
@@ -80,12 +115,6 @@ import { NgxTurnstileModule } from 'ngx-turnstile';
       </main>
     </div>
   `,
-  imports: [NgxTurnstileModule],
+  imports: [RouterModule],
 })
-export class AppComponent {
-  siteKey = '1x00000000000000000000AA';
-
-  onResolved(response: string | null) {
-    console.log(response);
-  }
-}
+export class AppComponent {}

--- a/projects/ngx-turnstile-demo/src/app/app.component.ts
+++ b/projects/ngx-turnstile-demo/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
 @Component({

--- a/projects/ngx-turnstile-demo/src/app/examples/event-binding/event-binding-example.component.ts
+++ b/projects/ngx-turnstile-demo/src/app/examples/event-binding/event-binding-example.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { NgxTurnstileModule } from 'ngx-turnstile';
+
+@Component({
+  selector: 'app-regular-example',
+  standalone: true,
+  template: `
+    <ng-container>
+      <ngx-turnstile
+        [siteKey]="siteKey"
+        theme="light"
+        (resolved)="onResolved($event)"
+      ></ngx-turnstile>
+    </ng-container>
+  `,
+  imports: [NgxTurnstileModule],
+})
+export class EventBindingExampleComponent {
+  siteKey = '1x00000000000000000000AA';
+
+  onResolved(response: string | null) {
+    console.log(response);
+  }
+}

--- a/projects/ngx-turnstile-demo/src/app/examples/reactive-form/reactive-form-example.component.ts
+++ b/projects/ngx-turnstile-demo/src/app/examples/reactive-form/reactive-form-example.component.ts
@@ -1,0 +1,44 @@
+import { Component, OnInit } from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { NgxTurnstileFormsModule, NgxTurnstileModule } from 'ngx-turnstile';
+
+@Component({
+  selector: 'app-reactive-form-example',
+  standalone: true,
+  template: ` <ng-container>
+    <ngx-turnstile
+      [siteKey]="siteKey"
+      theme="light"
+      [formControl]="tokenControl"
+    ></ngx-turnstile>
+
+    <div class="p-1">Value: {{ tokenControl.value }}</div>
+    <button
+      type="button"
+      class="btn btn-secondary btn-lg w-100 mb-3"
+      (click)="setToInvalidValue()"
+    >
+      Set to Invalid Value
+    </button>
+    <button
+      type="button"
+      class="btn btn-secondary btn-lg w-100 mb-3"
+      (click)="tokenControl.reset()"
+    >
+      Reset Form Control
+    </button>
+  </ng-container>`,
+  imports: [NgxTurnstileModule, NgxTurnstileFormsModule, ReactiveFormsModule],
+})
+export class ReactiveFormExampleComponent implements OnInit {
+  siteKey = '1x00000000000000000000AA';
+  tokenControl = new FormControl();
+
+  ngOnInit(): void {
+    this.tokenControl = new FormControl();
+  }
+
+  setToInvalidValue() {
+    this.tokenControl.setValue('this is an invalid value');
+  }
+}

--- a/projects/ngx-turnstile-demo/src/app/examples/template-driven-form/template-driven-form-example.component.ts
+++ b/projects/ngx-turnstile-demo/src/app/examples/template-driven-form/template-driven-form-example.component.ts
@@ -1,0 +1,34 @@
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { NgxTurnstileModule, NgxTurnstileFormsModule } from 'ngx-turnstile';
+
+@Component({
+  selector: 'app-reactive-form-example',
+  standalone: true,
+  template: ` <ng-container
+    ><ngx-turnstile
+      [siteKey]="siteKey"
+      theme="light"
+      [(ngModel)]="token"
+    ></ngx-turnstile>
+
+    <div class="p-1">Value: {{ token }}</div>
+    <button
+      type="button"
+      class="btn btn-secondary btn-lg w-100 mb-3"
+      (click)="setToInvalidValue()"
+    >
+      Set to Invalid Value
+    </button>
+  </ng-container>`,
+  imports: [NgxTurnstileModule, NgxTurnstileFormsModule, FormsModule],
+})
+export class TemplateDrivenFormExampleComponent {
+  token: string = '';
+
+  siteKey = '1x00000000000000000000AA';
+
+  setToInvalidValue() {
+    this.token = 'this is an invalid value';
+  }
+}

--- a/projects/ngx-turnstile-demo/src/app/routes.ts
+++ b/projects/ngx-turnstile-demo/src/app/routes.ts
@@ -1,0 +1,23 @@
+import { Routes } from '@angular/router';
+import { EventBindingExampleComponent } from './examples/event-binding/event-binding-example.component';
+import { ReactiveFormExampleComponent } from './examples/reactive-form/reactive-form-example.component';
+import { TemplateDrivenFormExampleComponent } from './examples/template-driven-form/template-driven-form-example.component';
+
+export const APP_ROUTES: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    component: EventBindingExampleComponent,
+    title: 'Event Binding Example',
+  },
+  {
+    path: 'reactive-form-example',
+    component: ReactiveFormExampleComponent,
+    title: 'Reactive Form Example',
+  },
+  {
+    path: 'template-driven-form-example',
+    component: TemplateDrivenFormExampleComponent,
+    title: 'Template Driven Form Example',
+  },
+];

--- a/projects/ngx-turnstile-demo/src/main.ts
+++ b/projects/ngx-turnstile-demo/src/main.ts
@@ -1,6 +1,8 @@
 import { enableProdMode } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
 import { AppComponent } from './app/app.component';
+import { APP_ROUTES } from './app/routes';
 
 import { environment } from './environments/environment';
 
@@ -8,4 +10,6 @@ if (environment.production) {
   enableProdMode();
 }
 
-bootstrapApplication(AppComponent);
+bootstrapApplication(AppComponent, {
+  providers: [provideRouter(APP_ROUTES)],
+});

--- a/projects/ngx-turnstile/.eslintrc.json
+++ b/projects/ngx-turnstile/.eslintrc.json
@@ -16,7 +16,6 @@
           "error",
           {
             "type": "attribute",
-            "prefix": "ngx",
             "style": "camelCase"
           }
         ],

--- a/projects/ngx-turnstile/src/lib/ngx-turnstile-forms.module.ts
+++ b/projects/ngx-turnstile/src/lib/ngx-turnstile-forms.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { NgxTurnstileValueAccessorDirective } from './ngx-turnstile-value-accessor.directive';
+import { NgxTurnstileModule } from './ngx-turnstile.module';
+
+@NgModule({
+  declarations: [NgxTurnstileValueAccessorDirective],
+  imports: [NgxTurnstileModule],
+  exports: [NgxTurnstileValueAccessorDirective],
+})
+export class NgxTurnstileFormsModule {}

--- a/projects/ngx-turnstile/src/lib/ngx-turnstile-value-accessor.directive.ts
+++ b/projects/ngx-turnstile/src/lib/ngx-turnstile-value-accessor.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, forwardRef, HostListener, OnInit } from '@angular/core';
+import { Directive, forwardRef, OnInit } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { NgxTurnstileComponent } from './ngx-turnstile.component';
 

--- a/projects/ngx-turnstile/src/lib/ngx-turnstile-value-accessor.directive.ts
+++ b/projects/ngx-turnstile/src/lib/ngx-turnstile-value-accessor.directive.ts
@@ -1,0 +1,53 @@
+import { Directive, forwardRef, HostListener, OnInit } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { NgxTurnstileComponent } from './ngx-turnstile.component';
+
+@Directive({
+  selector:
+    'ngx-turnstile[formControl], ngx-turnstile[formControlName], ngx-turnstile[ngModel]',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => NgxTurnstileValueAccessorDirective),
+      multi: true,
+    },
+  ],
+})
+export class NgxTurnstileValueAccessorDirective
+  implements ControlValueAccessor, OnInit
+{
+  private onChange!: (value: string) => void;
+  private onTouched!: () => void;
+  private resolved: boolean = false;
+
+  constructor(private turnstileComp: NgxTurnstileComponent) {}
+
+  ngOnInit(): void {
+    this.turnstileComp.resolved.subscribe((token: string) => {
+      this.resolved = !!token;
+
+      if (this.onChange) {
+        this.onChange(token);
+      }
+
+      if (this.onTouched) {
+        this.onTouched();
+      }
+    });
+  }
+
+  // Prevent form control from setting token value
+  writeValue(value: any): void {
+    // reset turnstile component if form control sets the value after already receiving a valid token
+    if (this.resolved) {
+      this.resolved = false;
+      this.turnstileComp.reset();
+    }
+  }
+  registerOnChange(fn: any): void {
+    this.onChange = fn;
+  }
+  registerOnTouched(fn: any): void {
+    this.onTouched = fn;
+  }
+}

--- a/projects/ngx-turnstile/src/lib/ngx-turnstile.component.ts
+++ b/projects/ngx-turnstile/src/lib/ngx-turnstile.component.ts
@@ -94,6 +94,12 @@ export class NgxTurnstileComponent implements AfterViewInit, OnDestroy {
     document.head.appendChild(script);
   }
 
+  reset() {
+    if (this.widgetId) {
+      window.turnstile.reset(this.widgetId);
+    }
+  }
+
   public ngOnDestroy(): void {
     window.turnstile.remove(this.widgetId);
   }

--- a/projects/ngx-turnstile/src/lib/ngx-turnstile.component.ts
+++ b/projects/ngx-turnstile/src/lib/ngx-turnstile.component.ts
@@ -71,7 +71,7 @@ export class NgxTurnstileComponent implements AfterViewInit, OnDestroy {
         this.zone.run(() => this.resolved.emit(token));
       },
       'expired-callback': () => {
-        this.zone.run(() => this.resolved.emit(null));
+        this.zone.run(() => this.reset());
       },
     };
 
@@ -96,6 +96,7 @@ export class NgxTurnstileComponent implements AfterViewInit, OnDestroy {
 
   reset() {
     if (this.widgetId) {
+      this.resolved.emit(null);
       window.turnstile.reset(this.widgetId);
     }
   }

--- a/projects/ngx-turnstile/src/public-api.ts
+++ b/projects/ngx-turnstile/src/public-api.ts
@@ -5,3 +5,5 @@
 export * from './lib/ngx-turnstile.service';
 export * from './lib/ngx-turnstile.component';
 export * from './lib/ngx-turnstile.module';
+export * from './lib/ngx-turnstile-value-accessor.directive';
+export * from './lib/ngx-turnstile-forms.module';


### PR DESCRIPTION
Added support for both template driven and reactive forms by creating a new directive and implementing the ControlValueAccessor interface. Updated README and demo to include examples for both form types.

Resolves #5