### PR TITLE
chore(lib): @angular >=16.0.0

### DIFF
--- a/projects/ngx-turnstile/package.json
+++ b/projects/ngx-turnstile/package.json
@@ -16,8 +16,8 @@
     "cloudflare-turnstile"
   ],
   "peerDependencies": {
-    "@angular/common": "^16.0.0",
-    "@angular/core": "^16.0.0"
+    "@angular/common": ">=16.0.0",
+    "@angular/core": ">=16.0.0"
   },
   "dependencies": {
     "tslib": "^2.5.2"


### PR DESCRIPTION
Accept version over the v16.0.0 to be able to use it with angular v17

Closes: https://github.com/verto-health/ngx-turnstile/issues/18