### PR TITLE
Add error callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ These options are well documented in the [Cloudflare Docs](https://developers.cl
 ### Events
 
 - `resolved(response: string)`. Occurs when the CAPTCHA resolution value changed.
+- `errored(errorCode: string)`. Occurs when the CAPTCHA widget returned an [error code](https://developers.cloudflare.com/turnstile/troubleshooting/client-side-errors/#error-codes).
 
 ### Example
 

--- a/projects/ngx-turnstile-demo/src/app/examples/event-binding/event-binding-example.component.ts
+++ b/projects/ngx-turnstile-demo/src/app/examples/event-binding/event-binding-example.component.ts
@@ -10,6 +10,7 @@ import { NgxTurnstileModule } from 'ngx-turnstile';
         [siteKey]="siteKey"
         theme="light"
         (resolved)="onResolved($event)"
+        (errored)="onErrored($event)"
       ></ngx-turnstile>
     </ng-container>
   `,
@@ -19,6 +20,10 @@ export class EventBindingExampleComponent {
   siteKey = '1x00000000000000000000AA';
 
   onResolved(response: string | null) {
-    console.log(response);
+    console.log('onResolved', response);
+  }
+
+  onErrored(errorCode: string | null) {
+    console.log('onErrored', errorCode);
   }
 }

--- a/projects/ngx-turnstile/src/lib/interfaces/turnstile-options.ts
+++ b/projects/ngx-turnstile/src/lib/interfaces/turnstile-options.ts
@@ -3,7 +3,7 @@ export interface TurnstileOptions {
   action?: string;
   cData?: string;
   callback?: (token: string) => void;
-  'error-callback'?: () => void;
+  'error-callback'?: (errorCode: string) => boolean;
   'expired-callback'?: () => void;
   theme?: 'light' | 'dark' | 'auto';
   tabindex?: number;

--- a/projects/ngx-turnstile/src/lib/ngx-turnstile.component.ts
+++ b/projects/ngx-turnstile/src/lib/ngx-turnstile.component.ts
@@ -45,6 +45,7 @@ export class NgxTurnstileComponent implements AfterViewInit, OnDestroy {
   @Input() appearance?: 'always' | 'execute' | 'interaction-only' = 'always';
 
   @Output() resolved = new EventEmitter<string | null>();
+  @Output() errored = new EventEmitter<string | null>();
 
   private widgetId!: string;
 
@@ -71,6 +72,11 @@ export class NgxTurnstileComponent implements AfterViewInit, OnDestroy {
       appearance: this.appearance,
       callback: (token: string) => {
         this.zone.run(() => this.resolved.emit(token));
+      },
+      'error-callback': (errorCode: string): boolean => {
+        this.zone.run(() => this.errored.emit(errorCode));
+        // Returning false causes Turnstile to log error code as a console warning.
+        return false;
       },
       'expired-callback': () => {
         this.zone.run(() => this.reset());


### PR DESCRIPTION
### Summary

Make ngx-turnstile emit error code when the widget encounters an error.

### Motivation

Currently, ngx-turnstile doesn't pass any [error-callback configuration](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations) to the Turnstile widget, so by default ["Turnstile will throw a JavaScript exception upon error"](https://developers.cloudflare.com/turnstile/troubleshooting/client-side-errors/#error-handling). This may cause quite a lot of noise in error tracking systems like Rollbar.

This PR adds an error-callback that emits the error code as a component output.

ngx-turnstile users can subscribe to this error code and handle it according to their needs, which helps to address issue #26.

### Caveats 

Ideally, the ngx-turnstile component should accept a callback `Function` as input:
- This function should take a string and return a boolean.
- If no such function was provided, ngx-turnstile should not pass the 'error-callback' option to Turnstile.

However, I'm not sure how to implement that, so I've replicated the EventEmitter approach from the `resolved` output. Now, in order to intercept the error code, ngx-turnstile will _always_ pass 'error-callback' to the Turnstile widget.

### Warning: breaking changes

The caveats above would mean that ngx-turnstile users will no longer see exceptions being thrown. Instead, they'll see the error code logged as a console warning.

(It would be great if someone could help with avoiding this breaking change!)