### PR TITLE
fix: duplicate script injection when navigating to different page

### DIFF
--- a/cypress/e2e/ngx-turnstile.cy.ts
+++ b/cypress/e2e/ngx-turnstile.cy.ts
@@ -12,4 +12,23 @@ describe('tests the ngx-turnstile library', () => {
     cy.wait(3000);
     cy.contains('Value: XXXX.DUMMY.TOKEN.XXXX');
   });
+
+  // visits multiple routes and makes sure script is not injected multiple times
+  it('Passes Visiting Multiple Routes Example', () => {
+    cy.visit(Cypress.env('reactiveFormUrl'));
+    cy.wait(3000);
+    cy.contains('Value: XXXX.DUMMY.TOKEN.XXXX');
+
+    cy.visit(Cypress.env('templateDrivenFormUrl'), {
+      onBeforeLoad(win) {
+        cy.spy(win.console, 'warn').as('consoleWarn');
+      },
+    });
+    cy.wait(3000);
+    cy.contains('Value: XXXX.DUMMY.TOKEN.XXXX');
+    cy.get('@consoleWarn').should(
+      'not.be.calledWith',
+      '[Cloudflare Turnstile] Turnstile already has been loaded. Was Turnstile imported multiple times?.',
+    );
+  });
 });


### PR DESCRIPTION
Resolves #29

Solution:
If the script is already injected, `onloadTurnstileCallback` is called manually to render a new turnstile widget.


