### PR TITLE
add parameters retry and size

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ The component supports these options as input:
 - `cData`
 - `theme`
 - `tabIndex`
+- `retry`
+- `size`
 
 These options are well documented in the [Cloudflare Docs](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations). The letter cases are adapted to camelCase to facilitate easy migration from `ng-recaptcha`.
 

--- a/projects/ngx-turnstile-demo/src/app/app.component.ts
+++ b/projects/ngx-turnstile-demo/src/app/app.component.ts
@@ -80,6 +80,13 @@ import { RouterModule } from '@angular/router';
           [routerLinkActive]="['route-active']"
           >Language Option Example</a
         >
+
+        <a
+          routerLink="/different-widget-size-example"
+          [routerLinkActive]="['route-active']"
+          >Different Widget Size Example</a
+        >
+        
       </div>
       <main class="form-signin">
         <form action="https://demo.turnstile.workers.dev/handler" method="POST">

--- a/projects/ngx-turnstile-demo/src/app/examples/different-size/different-size.component.ts
+++ b/projects/ngx-turnstile-demo/src/app/examples/different-size/different-size.component.ts
@@ -1,0 +1,36 @@
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { NgxTurnstileModule, NgxTurnstileFormsModule } from 'ngx-turnstile';
+
+
+@Component({
+  selector: 'app-different-size',
+  standalone: true,
+  template: ` <ng-container
+    ><ngx-turnstile
+      [siteKey]="siteKey"
+      theme="light"
+      size="compact"
+      [(ngModel)]="token"
+    ></ngx-turnstile>
+
+    <div class="p-1">Value: {{ token }}</div>
+    <button
+      type="button"
+      class="btn btn-secondary btn-lg w-100 mb-3"
+      (click)="setToInvalidValue()"
+    >
+    Appearance modes
+    </button>
+  </ng-container>`,
+  imports: [NgxTurnstileModule, NgxTurnstileFormsModule, FormsModule],
+})
+export class DifferentSizeComponent {
+  token: string = '';
+
+  siteKey = '1x00000000000000000000AA';
+
+  setToInvalidValue() {
+    this.token = 'this is an invalid value';
+  }
+}

--- a/projects/ngx-turnstile-demo/src/app/examples/template-driven-form/template-driven-form-example.component.ts
+++ b/projects/ngx-turnstile-demo/src/app/examples/template-driven-form/template-driven-form-example.component.ts
@@ -9,8 +9,6 @@ import { NgxTurnstileModule, NgxTurnstileFormsModule } from 'ngx-turnstile';
     ><ngx-turnstile
       [siteKey]="siteKey"
       theme="light"
-      retry="never"
-      size="normal"
       [(ngModel)]="token"
     ></ngx-turnstile>
 

--- a/projects/ngx-turnstile-demo/src/app/examples/template-driven-form/template-driven-form-example.component.ts
+++ b/projects/ngx-turnstile-demo/src/app/examples/template-driven-form/template-driven-form-example.component.ts
@@ -9,6 +9,8 @@ import { NgxTurnstileModule, NgxTurnstileFormsModule } from 'ngx-turnstile';
     ><ngx-turnstile
       [siteKey]="siteKey"
       theme="light"
+      retry="never"
+      size="normal"
       [(ngModel)]="token"
     ></ngx-turnstile>
 

--- a/projects/ngx-turnstile-demo/src/app/routes.ts
+++ b/projects/ngx-turnstile-demo/src/app/routes.ts
@@ -3,6 +3,7 @@ import { EventBindingExampleComponent } from './examples/event-binding/event-bin
 import { ReactiveFormExampleComponent } from './examples/reactive-form/reactive-form-example.component';
 import { TemplateDrivenFormExampleComponent } from './examples/template-driven-form/template-driven-form-example.component';
 import { LanguageOptionComponent } from './examples/language-option/language-option.component';
+import { DifferentSizeComponent } from './examples/different-size/different-size.component';
 
 export const APP_ROUTES: Routes = [
   {
@@ -26,4 +27,9 @@ export const APP_ROUTES: Routes = [
     component: TemplateDrivenFormExampleComponent,
     title: 'Template Driven Form Example',
   },
+  {
+    path: 'different-widget-size-example',
+    component: DifferentSizeComponent,
+    title: 'Different Widget Size Example',
+  }
 ];

--- a/projects/ngx-turnstile/src/lib/interfaces/turnstile-options.ts
+++ b/projects/ngx-turnstile/src/lib/interfaces/turnstile-options.ts
@@ -9,4 +9,6 @@ export interface TurnstileOptions {
   language?: string;
   tabindex?: number;
   appearance?: 'always' | 'execute' | 'interaction-only';
+  retry?: 'never' | 'auto';
+  size?: 'normal' | 'flexible' | 'compact';
 }

--- a/projects/ngx-turnstile/src/lib/ngx-turnstile.component.ts
+++ b/projects/ngx-turnstile/src/lib/ngx-turnstile.component.ts
@@ -48,6 +48,8 @@ export class NgxTurnstileComponent implements OnDestroy {
   @Input() version: SupportedVersion = '0';
   @Input() tabIndex?: number;
   @Input() appearance?: 'always' | 'execute' | 'interaction-only' = 'always';
+  @Input() retry?: 'never' | 'auto' = 'auto';
+  @Input() size?: 'normal' | 'flexible' | 'compact' = 'normal';
 
   @Output() resolved = new EventEmitter<string | null>();
   @Output() errored = new EventEmitter<string | null>();
@@ -79,6 +81,8 @@ export class NgxTurnstileComponent implements OnDestroy {
       action: this.action,
       cData: this.cData,
       appearance: this.appearance,
+      retry: this.retry,
+      size: this.size,
       callback: (token: string) => {
         this.zone.run(() => this.resolved.emit(token));
       },


### PR DESCRIPTION
Hi everyone, added the retry and size parameters to allow controlling automatic retries and the size of the javascript component with the options indicated in the turnstile documentation.

Regards,

Jorge.