### PR TITLE
Convert to standalone component

### DIFF
--- a/projects/ngx-turnstile/src/lib/ngx-turnstile.component.spec.ts
+++ b/projects/ngx-turnstile/src/lib/ngx-turnstile.component.spec.ts
@@ -8,7 +8,7 @@ describe('NgxTurnstileComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [NgxTurnstileComponent],
+      imports: [NgxTurnstileComponent],
     }).compileComponents();
 
     fixture = TestBed.createComponent(NgxTurnstileComponent);

--- a/projects/ngx-turnstile/src/lib/ngx-turnstile.component.ts
+++ b/projects/ngx-turnstile/src/lib/ngx-turnstile.component.ts
@@ -38,6 +38,7 @@ type SupportedVersion = '0';
   selector: 'ngx-turnstile',
   template: ``,
   exportAs: 'ngx-turnstile',
+  standalone: true
 })
 export class NgxTurnstileComponent implements OnDestroy {
   @Input() siteKey!: string;

--- a/projects/ngx-turnstile/src/lib/ngx-turnstile.module.ts
+++ b/projects/ngx-turnstile/src/lib/ngx-turnstile.module.ts
@@ -2,8 +2,7 @@ import { NgModule } from '@angular/core';
 import { NgxTurnstileComponent } from './ngx-turnstile.component';
 
 @NgModule({
-  declarations: [NgxTurnstileComponent],
-  imports: [],
+  imports: [NgxTurnstileComponent],
   exports: [NgxTurnstileComponent],
 })
 export class NgxTurnstileModule {}


### PR DESCRIPTION
## Summary

Convert NgxTurnstileComponent to a standalone component. NgxTurnstileModule is maintained for any code still using it. (I wouldn't suggest removing it without a larger version bump due to backwards-compatibility issues.)

#### Testing

Testing was performed on production code in a localhost environment and no issues were noted.