### PR TITLE
Ensure every widget on the page renders (build on #61)

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     reactiveFormUrl: 'http://0.0.0.0:4200/reactive-form-example',
     templateDrivenFormUrl: 'http://0.0.0.0:4200/template-driven-form-example',
     languageOptionUrl: 'http://0.0.0.0:4200/language-option-example',
+    multiWidgetUrl: 'http://0.0.0.0:4200/multi-widget-example',
   },
   e2e: {
     setupNodeEvents(on, config) {

--- a/cypress/e2e/ngx-turnstile.cy.ts
+++ b/cypress/e2e/ngx-turnstile.cy.ts
@@ -45,4 +45,15 @@ describe('tests the ngx-turnstile library', () => {
         cy.wrap($iframe).should('have.attr', 'src').and('include', 'FR');
       });
   });
+
+  // visits a page with two widgets and makes sure BOTH render (regression test
+  // for the callback-overwrite bug where only the last-created widget rendered)
+  it('Passes Multiple Widgets Example', () => {
+    cy.visit(Cypress.env('multiWidgetUrl'));
+    cy.wait(3000);
+    cy.get('ngx-turnstile').should('have.length', 2);
+    cy.get('ngx-turnstile').each(($widget) => {
+      cy.wrap($widget).find('div').shadow().find('iframe').should('exist');
+    });
+  });
 });

--- a/cypress/e2e/ngx-turnstile.cy.ts
+++ b/cypress/e2e/ngx-turnstile.cy.ts
@@ -46,8 +46,9 @@ describe('tests the ngx-turnstile library', () => {
       });
   });
 
-  // visits a page with two widgets and makes sure BOTH render (regression test
-  // for the callback-overwrite bug where only the last-created widget rendered)
+  // the page mounts a normal widget and a conditional one together on load;
+  // makes sure BOTH render (regression test for the callback-overwrite bug
+  // where only the last-created widget rendered)
   it('Passes Multiple Widgets Example', () => {
     cy.visit(Cypress.env('multiWidgetUrl'));
     cy.wait(3000);
@@ -57,8 +58,8 @@ describe('tests the ngx-turnstile library', () => {
     });
   });
 
-  // toggles a conditionally-rendered widget on/off (the repro from issue #49)
-  // and makes sure it renders without the "reading 'render'" TypeError
+  // toggles the conditionally-rendered widget off then on (the repro from
+  // issue #49) and makes sure it renders without the "reading 'render'" TypeError
   it('Passes Conditionally Rendered Widget Example', () => {
     const renderErrors: string[] = [];
     cy.on('uncaught:exception', (err) => {
@@ -75,23 +76,17 @@ describe('tests the ngx-turnstile library', () => {
     });
     cy.wait(3000);
 
-    // Mount, unmount, and re-mount the conditional widget.
-    cy.get('[data-cy="toggle-conditional-widget"]').check();
-    cy.wait(2000);
-    cy.get('ngx-turnstile').should('have.length', 3);
-    cy.get('ngx-turnstile')
-      .last()
-      .find('div')
-      .shadow()
-      .find('iframe')
-      .should('exist');
-
-    cy.get('[data-cy="toggle-conditional-widget"]').uncheck();
+    // Starts shown: normal widget + conditional widget.
     cy.get('ngx-turnstile').should('have.length', 2);
 
+    // Unmount the conditional widget.
+    cy.get('[data-cy="toggle-conditional-widget"]').uncheck();
+    cy.get('ngx-turnstile').should('have.length', 1);
+
+    // Re-mount it and make sure it renders again.
     cy.get('[data-cy="toggle-conditional-widget"]').check();
     cy.wait(2000);
-    cy.get('ngx-turnstile').should('have.length', 3);
+    cy.get('ngx-turnstile').should('have.length', 2);
     cy.get('ngx-turnstile')
       .last()
       .find('div')

--- a/cypress/e2e/ngx-turnstile.cy.ts
+++ b/cypress/e2e/ngx-turnstile.cy.ts
@@ -56,4 +56,55 @@ describe('tests the ngx-turnstile library', () => {
       cy.wrap($widget).find('div').shadow().find('iframe').should('exist');
     });
   });
+
+  // toggles a conditionally-rendered widget on/off (the repro from issue #49)
+  // and makes sure it renders without the "reading 'render'" TypeError
+  it('Passes Conditionally Rendered Widget Example', () => {
+    const renderErrors: string[] = [];
+    cy.on('uncaught:exception', (err) => {
+      renderErrors.push(err.message);
+      return false;
+    });
+
+    cy.visit(Cypress.env('multiWidgetUrl'), {
+      onBeforeLoad(win) {
+        cy.stub(win.console, 'error').callsFake((...args: unknown[]) => {
+          renderErrors.push(args.map(String).join(' '));
+        });
+      },
+    });
+    cy.wait(3000);
+
+    // Mount, unmount, and re-mount the conditional widget.
+    cy.get('[data-cy="toggle-conditional-widget"]').check();
+    cy.wait(2000);
+    cy.get('ngx-turnstile').should('have.length', 3);
+    cy.get('ngx-turnstile')
+      .last()
+      .find('div')
+      .shadow()
+      .find('iframe')
+      .should('exist');
+
+    cy.get('[data-cy="toggle-conditional-widget"]').uncheck();
+    cy.get('ngx-turnstile').should('have.length', 2);
+
+    cy.get('[data-cy="toggle-conditional-widget"]').check();
+    cy.wait(2000);
+    cy.get('ngx-turnstile').should('have.length', 3);
+    cy.get('ngx-turnstile')
+      .last()
+      .find('div')
+      .shadow()
+      .find('iframe')
+      .should('exist');
+
+    cy.then(() => {
+      const rendererrs = renderErrors.filter((e) => /reading 'render'/.test(e));
+      expect(
+        rendererrs,
+        `no "reading 'render'" TypeError (issue #49)`,
+      ).to.have.length(0);
+    });
+  });
 });

--- a/projects/ngx-turnstile-demo/src/app/app.component.ts
+++ b/projects/ngx-turnstile-demo/src/app/app.component.ts
@@ -86,6 +86,12 @@ import { RouterModule } from '@angular/router';
           [routerLinkActive]="['route-active']"
           >Different Widget Size Example</a
         >
+
+        <a
+          routerLink="/multi-widget-example"
+          [routerLinkActive]="['route-active']"
+          >Multiple Widgets Example</a
+        >
       </div>
       <main class="form-signin">
         <form action="https://demo.turnstile.workers.dev/handler" method="POST">

--- a/projects/ngx-turnstile-demo/src/app/examples/multi-widget/multi-widget.component.ts
+++ b/projects/ngx-turnstile-demo/src/app/examples/multi-widget/multi-widget.component.ts
@@ -1,0 +1,36 @@
+import { Component } from '@angular/core';
+import { NgxTurnstileModule } from 'ngx-turnstile';
+
+@Component({
+  selector: 'app-multi-widget-example',
+  standalone: true,
+  template: `
+    <ng-container>
+      <p>Both widgets below should render on the same page.</p>
+      <ngx-turnstile
+        [siteKey]="siteKey"
+        theme="light"
+        (resolved)="onResolved('widget-1', $event)"
+        (errored)="onErrored('widget-1', $event)"
+      ></ngx-turnstile>
+      <ngx-turnstile
+        [siteKey]="siteKey"
+        theme="light"
+        (resolved)="onResolved('widget-2', $event)"
+        (errored)="onErrored('widget-2', $event)"
+      ></ngx-turnstile>
+    </ng-container>
+  `,
+  imports: [NgxTurnstileModule],
+})
+export class MultiWidgetComponent {
+  siteKey = '1x00000000000000000000AA';
+
+  onResolved(widget: string, response: string | null) {
+    console.log('onResolved', widget, response);
+  }
+
+  onErrored(widget: string, errorCode: string | null) {
+    console.log('onErrored', widget, errorCode);
+  }
+}

--- a/projects/ngx-turnstile-demo/src/app/examples/multi-widget/multi-widget.component.ts
+++ b/projects/ngx-turnstile-demo/src/app/examples/multi-widget/multi-widget.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { NgIf } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { NgxTurnstileModule } from 'ngx-turnstile';
 
 @Component({
@@ -19,12 +21,33 @@ import { NgxTurnstileModule } from 'ngx-turnstile';
         (resolved)="onResolved('widget-2', $event)"
         (errored)="onErrored('widget-2', $event)"
       ></ngx-turnstile>
+
+      <label>
+        <input
+          type="checkbox"
+          data-cy="toggle-conditional-widget"
+          [(ngModel)]="showConditionalWidget"
+        />
+        Show conditionally-rendered widget
+      </label>
+
+      <ngx-turnstile
+        *ngIf="showConditionalWidget"
+        [siteKey]="siteKey"
+        theme="light"
+        (resolved)="onResolved('widget-conditional', $event)"
+        (errored)="onErrored('widget-conditional', $event)"
+      ></ngx-turnstile>
     </ng-container>
   `,
-  imports: [NgxTurnstileModule],
+  imports: [NgxTurnstileModule, NgIf, FormsModule],
 })
 export class MultiWidgetComponent {
   siteKey = '1x00000000000000000000AA';
+
+  // Toggled by the checkbox to mount/unmount a widget on demand — reproduces
+  // the conditional-render race from issue #49.
+  showConditionalWidget = false;
 
   onResolved(widget: string, response: string | null) {
     console.log('onResolved', widget, response);

--- a/projects/ngx-turnstile-demo/src/app/examples/multi-widget/multi-widget.component.ts
+++ b/projects/ngx-turnstile-demo/src/app/examples/multi-widget/multi-widget.component.ts
@@ -8,18 +8,17 @@ import { NgxTurnstileModule } from 'ngx-turnstile';
   standalone: true,
   template: `
     <ng-container>
-      <p>Both widgets below should render on the same page.</p>
+      <p>
+        A normally-rendered widget and a conditionally-rendered one. Both should
+        render on the same page; toggling the checkbox mounts/unmounts the
+        second one.
+      </p>
+
       <ngx-turnstile
         [siteKey]="siteKey"
         theme="light"
-        (resolved)="onResolved('widget-1', $event)"
-        (errored)="onErrored('widget-1', $event)"
-      ></ngx-turnstile>
-      <ngx-turnstile
-        [siteKey]="siteKey"
-        theme="light"
-        (resolved)="onResolved('widget-2', $event)"
-        (errored)="onErrored('widget-2', $event)"
+        (resolved)="onResolved('widget-normal', $event)"
+        (errored)="onErrored('widget-normal', $event)"
       ></ngx-turnstile>
 
       <label>
@@ -45,9 +44,10 @@ import { NgxTurnstileModule } from 'ngx-turnstile';
 export class MultiWidgetComponent {
   siteKey = '1x00000000000000000000AA';
 
-  // Toggled by the checkbox to mount/unmount a widget on demand — reproduces
-  // the conditional-render race from issue #49.
-  showConditionalWidget = false;
+  // Rendered on load so both widgets mount together (exercises the shared
+  // script-load callback), and toggled off/on to reproduce the
+  // conditional-render race from issue #49.
+  showConditionalWidget = true;
 
   onResolved(widget: string, response: string | null) {
     console.log('onResolved', widget, response);

--- a/projects/ngx-turnstile-demo/src/app/routes.ts
+++ b/projects/ngx-turnstile-demo/src/app/routes.ts
@@ -4,6 +4,7 @@ import { ReactiveFormExampleComponent } from './examples/reactive-form/reactive-
 import { TemplateDrivenFormExampleComponent } from './examples/template-driven-form/template-driven-form-example.component';
 import { LanguageOptionComponent } from './examples/language-option/language-option.component';
 import { DifferentSizeComponent } from './examples/different-size/different-size.component';
+import { MultiWidgetComponent } from './examples/multi-widget/multi-widget.component';
 
 export const APP_ROUTES: Routes = [
   {
@@ -31,5 +32,10 @@ export const APP_ROUTES: Routes = [
     path: 'different-widget-size-example',
     component: DifferentSizeComponent,
     title: 'Different Widget Size Example',
+  },
+  {
+    path: 'multi-widget-example',
+    component: MultiWidgetComponent,
+    title: 'Multiple Widgets Example',
   },
 ];

--- a/projects/ngx-turnstile/src/lib/ngx-turnstile.component.ts
+++ b/projects/ngx-turnstile/src/lib/ngx-turnstile.component.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  AfterViewInit,
   ElementRef,
   Input,
   NgZone,
@@ -8,9 +7,13 @@ import {
   EventEmitter,
   OnDestroy,
   Inject,
+  PLATFORM_ID,
   afterNextRender,
+  signal,
+  computed,
 } from '@angular/core';
-import { DOCUMENT } from '@angular/common';
+import { toObservable, takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { TurnstileOptions } from './interfaces/turnstile-options';
 
 declare global {
@@ -34,6 +37,11 @@ const SCRIPT_ID = 'ngx-turnstile';
 const CALLBACK_NAME = 'onloadTurnstileCallback';
 type SupportedVersion = '0';
 
+// Every mounted component waiting for the Turnstile script to finish loading.
+// A single global onload callback notifies all of them, so multiple widgets on
+// the same page each get rendered (not just the last one that was created).
+const scriptLoadListeners = new Set<() => void>();
+
 @Component({
   selector: 'ngx-turnstile',
   template: ``,
@@ -55,14 +63,45 @@ export class NgxTurnstileComponent implements OnDestroy {
   @Output() resolved = new EventEmitter<string | null>();
   @Output() errored = new EventEmitter<string | null>();
 
-  private widgetId!: string;
+  private widgetId = signal<string | null | undefined>(undefined);
+
+  /** Whether the Cloudflare Turnstile script has finished loading. */
+  public scriptLoaded = signal(false);
+
+  /** Whether a widget is currently rendered. Clients can watch this signal. */
+  public widgetLoaded = computed(() => !!this.widgetId());
+
+  // Notifies this instance when the shared script finishes loading. Kept as a
+  // stable reference so it can be removed from the listener set on destroy.
+  private onScriptLoad = (): void =>
+    this.zone.run(() => this.scriptLoaded.set(true));
 
   constructor(
     private elementRef: ElementRef<HTMLElement>,
     private zone: NgZone,
     @Inject(DOCUMENT) private document: Document,
+    @Inject(PLATFORM_ID) private platformId: Object,
   ) {
-    afterNextRender(() => this.createWidget());
+    // Touching `window` is only safe in the browser (skip during SSR).
+    if (isPlatformBrowser(this.platformId)) {
+      this.loadScript();
+    }
+
+    // Render once the host element exists (if the script is already loaded).
+    afterNextRender(() => {
+      if (this.scriptLoaded() && !this.widgetLoaded()) {
+        this.createWidget();
+      }
+    });
+
+    // Render once the script finishes loading (if not already rendered).
+    toObservable(this.scriptLoaded)
+      .pipe(takeUntilDestroyed())
+      .subscribe((scriptLoaded) => {
+        if (scriptLoaded && !this.widgetLoaded()) {
+          this.createWidget();
+        }
+      });
   }
 
   private _getCloudflareTurnstileUrl(): string {
@@ -73,8 +112,43 @@ export class NgxTurnstileComponent implements OnDestroy {
     throw 'Version not defined in ngx-turnstile component.';
   }
 
+  private loadScript(): void {
+    // Script already present (e.g. loaded by another widget or a prior route).
+    if (window.turnstile) {
+      this.scriptLoaded.set(true);
+      return;
+    }
+
+    // Register to be notified when the shared script finishes loading.
+    scriptLoadListeners.add(this.onScriptLoad);
+
+    // A single global callback fans out to every waiting instance.
+    window[CALLBACK_NAME] = () => {
+      // Copy then clear so a listener re-registering mid-notification is safe.
+      const listeners = Array.from(scriptLoadListeners);
+      scriptLoadListeners.clear();
+      listeners.forEach((listener) => listener());
+    };
+
+    // Only inject the script once, even with several widgets on the page.
+    const scriptPending = !!this.document.getElementById(SCRIPT_ID);
+    if (!scriptPending) {
+      const script = this.document.createElement('script');
+      script.src = `${this._getCloudflareTurnstileUrl()}?render=explicit&onload=${CALLBACK_NAME}`;
+      script.id = SCRIPT_ID;
+      script.async = true;
+      script.defer = true;
+      this.document.head.appendChild(script);
+    }
+  }
+
   public createWidget(): void {
-    let turnstileOptions: TurnstileOptions = {
+    // Only render once the script is loaded and the host element exists.
+    if (!this.scriptLoaded() || !this.elementRef?.nativeElement) {
+      return;
+    }
+
+    const turnstileOptions: TurnstileOptions = {
       sitekey: this.siteKey,
       theme: this.theme,
       language: this.language,
@@ -97,44 +171,30 @@ export class NgxTurnstileComponent implements OnDestroy {
       },
     };
 
-    window[CALLBACK_NAME] = () => {
-      if (!this.elementRef?.nativeElement) {
-        return;
-      }
+    // Remove any existing widget so re-rendering doesn't create duplicates.
+    this.remove();
 
-      this.widgetId = window.turnstile.render(
-        this.elementRef.nativeElement,
-        turnstileOptions,
-      );
-    };
-
-    if (this.scriptLoaded()) {
-      window[CALLBACK_NAME]();
-      return;
-    }
-
-    const script = this.document.createElement('script');
-    script.src = `${this._getCloudflareTurnstileUrl()}?render=explicit&onload=${CALLBACK_NAME}`;
-    script.id = SCRIPT_ID;
-    script.async = true;
-    script.defer = true;
-    this.document.head.appendChild(script);
+    this.widgetId.set(
+      window.turnstile.render(this.elementRef.nativeElement, turnstileOptions),
+    );
   }
 
   public reset(): void {
-    if (this.widgetId) {
+    if (this.widgetLoaded()) {
       this.resolved.emit(null);
-      window.turnstile.reset(this.widgetId);
+      window.turnstile.reset(this.widgetId()!);
+    }
+  }
+
+  public remove(): void {
+    if (this.widgetLoaded()) {
+      window.turnstile.remove(this.widgetId()!);
+      this.widgetId.set(undefined);
     }
   }
 
   public ngOnDestroy(): void {
-    if (this.widgetId) {
-      window.turnstile.remove(this.widgetId);
-    }
-  }
-
-  public scriptLoaded(): boolean {
-    return !!this.document.getElementById(SCRIPT_ID);
+    scriptLoadListeners.delete(this.onScriptLoad);
+    this.remove();
   }
 }


### PR DESCRIPTION
## Summary

Builds on @sut123's script-race rework in #61 and addresses two issues surfaced in review of that PR. Opened as a separate branch so it can land cleanly on top of the latest `main`.

Fixes #49. Resolves #38.

## Background

#61 correctly moves script loading earlier and drives widget creation off signals, fixing the render-before-script-loaded race. Two problems remained:

1. **Multiple widgets on one page — only the last one rendered.** Each instance set `window[onloadTurnstileCallback]` to a closure that flipped *its own* `scriptLoaded` signal, so the last component constructed won the callback. When the script finished loading, only that instance was notified and earlier widgets stayed blank.
2. **SSR breakage.** Script loading now runs in the constructor, which dereferenced `window` during server-side rendering (the component was previously SSR-safe via `DOCUMENT` + `afterNextRender`).

## Changes

- **Shared callback fan-out:** a single module-level `onload` callback notifies a `Set` of registered listeners, so every mounted widget renders. Instances deregister on destroy.
- **SSR-safe:** `loadScript()` is gated behind `isPlatformBrowser(PLATFORM_ID)`, so `window` is only touched in the browser.
- **Cleanup:** the `scriptLoaded` subscription is torn down with `takeUntilDestroyed()`; `createWidget()`'s render path is flattened.
- Keeps the good parts of #61: immediate script load, `remove()`-before-render (no duplicate widgets), single-injection de-dup, and the `widgetLoaded` signal clients can watch.
- **Demo:** new "Multiple Widgets Example" page rendering two widgets at once.
- **Test:** Cypress e2e asserting both widgets render (regression coverage for issue 1).

## Testing

- `ng build ngx-turnstile` and `ng build ngx-turnstile-demo` — pass
- `ng lint` and `prettier --check` — pass
- `cypress run` — 5/5 e2e passing, including the new multi-widget test

All changes remain Angular 16-compatible (basic `signal`/`computed`/`toObservable` only).

Credit to @sut123 for the original fix in #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)