### PR TITLE
feat: support full Turnstile render parameter set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# Local design/brainstorming docs (not part of the published package)
+docs/superpowers/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,29 @@ npm install ngx-turnstile --save
 
 ## Quickstart
 
-To start, import the NgxTurnstileModule in your app module.
+`NgxTurnstileComponent` is a standalone component. Import it directly into any standalone component (or `NgModule`) that needs it:
+
+```typescript
+// app.component.ts
+import { Component } from "@angular/core";
+import { NgxTurnstileComponent } from "ngx-turnstile";
+
+@Component({
+  selector: "my-app",
+  standalone: true,
+  imports: [NgxTurnstileComponent],
+  template: `<ngx-turnstile [siteKey]="siteKey" (resolved)="sendCaptchaResponse($event)" theme="auto" [tabIndex]="0"></ngx-turnstile>`,
+})
+export class MyApp {
+  siteKey = "<YOUR_SITE_KEY>";
+
+  sendCaptchaResponse(captchaResponse: string | null) {
+    console.log(`Resolved captcha with response: ${captchaResponse}`);
+  }
+}
+```
+
+If you use `NgModule`s, you can instead import `NgxTurnstileModule`:
 
 ```typescript
 // app.module.ts
@@ -31,34 +53,17 @@ import { MyApp } from "./app.component.ts";
 export class MyAppModule {}
 ```
 
-After that, you are free to use the component anywhere:
-
-```typescript
-// app.component.ts
-import { Component } from "@angular/core";
-
-@Component({
-  selector: "my-app",
-  template: `<ngx-turnstile [siteKey]="siteKey" (resolved)="sendCaptchaResponse($event)" theme="auto" [tabIndex]="0"></ngx-turnstile>`,
-})
-export class MyApp {
-  sendCaptchaResponse(captchaResponse: string) {
-    console.log(`Resolved captcha with response: ${captchaResponse}`);
-  }
-}
-```
-
 ## Usage with @angular/forms
 
-Import both NgxTurnstileModule and NgxTurnstileFormsModule modules in your app module.
+Import both `NgxTurnstileModule` and `NgxTurnstileFormsModule` modules in your app module.
 
 ```typescript
 import { NgxTurnstileModule, NgxTurnstileFormsModule } from "ngx-turnstile";
 ```
 
-Then import either FormsModule or ReactiveFormsModule from @angular/forms depending on the type of form you want to use.
+Then import either `FormsModule` or `ReactiveFormsModule` from `@angular/forms` depending on the type of form you want to use.
 
-You can then use the ngModel, formControl or formControlName directives on the component depending on which module you imported from @angular/forms.
+You can then use the `ngModel`, `formControl` or `formControlName` directives on the component depending on which module you imported from `@angular/forms`.
 
 ### Reactive Form Example
 
@@ -72,26 +77,47 @@ You can then use the ngModel, formControl or formControlName directives on the c
 <ngx-turnstile [siteKey]="siteKey" theme="light" [(ngModel)]="token"></ngx-turnstile>
 ```
 
-The component is read-only, meaning that you should not update the control with a custom value. Updating the control value will reset the component
+The component is read-only, meaning that you should not update the control with a custom value. Updating the control value will reset the component.
 
 ## API
 
-The component supports these options as input:
+### Inputs
 
-- `siteKey`
-- `action`
-- `cData`
-- `theme`
-- `tabIndex`
-- `retry`
-- `size`
+The letter cases are adapted to camelCase to facilitate easy migration from `ng-recaptcha`. Each input maps to the corresponding [Cloudflare render parameter](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/widget-configurations/).
 
-These options are well documented in the [Cloudflare Docs](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations). The letter cases are adapted to camelCase to facilitate easy migration from `ng-recaptcha`.
+| Input                 | Type                                          | Default                   | Description                                                                                                                                                                             |
+| --------------------- | --------------------------------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `siteKey`             | `string` (required)                           | —                         | Your widget's sitekey, created when the widget is created.                                                                                                                              |
+| `action`              | `string`                                      | —                         | A customer value to differentiate widgets under the same sitekey (up to 32 chars: alphanumeric, `_`, `-`). Returned upon validation.                                                    |
+| `cData`               | `string`                                      | —                         | A customer payload attached to the challenge (up to 255 chars: alphanumeric, `_`, `-`). Returned upon validation.                                                                       |
+| `theme`               | `'light' \| 'dark' \| 'auto'`                 | `'auto'`                  | Widget theme. `auto` respects the visitor's preference.                                                                                                                                 |
+| `language`            | `string`                                      | `'auto'`                  | `auto`, or an ISO 639-1 code (e.g. `en`) / language-country code (e.g. `en-US`). See [supported languages](https://developers.cloudflare.com/turnstile/reference/supported-languages/). |
+| `tabIndex`            | `number`                                      | `0`                       | The `tabindex` of Turnstile's iframe for accessibility.                                                                                                                                 |
+| `appearance`          | `'always' \| 'execute' \| 'interaction-only'` | `'always'`                | Controls when the widget is visible. See [Appearance modes](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#appearance-modes).                           |
+| `execution`           | `'render' \| 'execute'`                       | `'render'`                | Controls when to obtain the token. See [Execution modes](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#execution-modes).                               |
+| `retry`               | `'auto' \| 'never'`                           | `'auto'`                  | Whether the widget automatically retries to obtain a token on failure.                                                                                                                  |
+| `retryInterval`       | `number`                                      | `8000`                    | When `retry` is `auto`, the time between retry attempts in ms. Positive integer less than `900000`.                                                                                     |
+| `refreshExpired`      | `'auto' \| 'manual' \| 'never'`               | `'auto'`                  | Behavior when the token expires.                                                                                                                                                        |
+| `refreshTimeout`      | `'auto' \| 'manual' \| 'never'`               | `'auto'`                  | Behavior when an interactive challenge times out. Only applies to widgets in Managed mode.                                                                                              |
+| `size`                | `'normal' \| 'flexible' \| 'compact'`         | `'normal'`                | Widget size.                                                                                                                                                                            |
+| `responseField`       | `boolean`                                     | `true`                    | Whether to create a hidden input element containing the response token.                                                                                                                 |
+| `responseFieldName`   | `string`                                      | `'cf-turnstile-response'` | Name of the hidden input element.                                                                                                                                                       |
+| `feedbackEnabled`     | `boolean`                                     | `true`                    | Allows Cloudflare to gather visitor feedback upon widget failure.                                                                                                                       |
+| `offlabelShowPrivacy` | `boolean`                                     | `true`                    | Displays the privacy link for unbranded Turnstile widgets.                                                                                                                              |
+| `offlabelShowHelp`    | `boolean`                                     | `true`                    | Displays the help link for unbranded Turnstile widgets.                                                                                                                                 |
 
-### Events
+### Outputs
 
-- `resolved(response: string)`. Occurs when the CAPTCHA resolution value changed.
-- `errored(errorCode: string)`. Occurs when the CAPTCHA widget returned an [error code](https://developers.cloudflare.com/turnstile/troubleshooting/client-side-errors/#error-codes).
+| Output              | Payload          | Description                                                                                                                                   |
+| ------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `resolved`          | `string \| null` | Emitted when the CAPTCHA resolution value changes. Emits `null` when the widget is reset (e.g. on token expiry).                              |
+| `errored`           | `string \| null` | Emitted when the widget returns an [error code](https://developers.cloudflare.com/turnstile/troubleshooting/client-side-errors/#error-codes). |
+| `beforeInteractive` | `void`           | Emitted before the challenge enters interactive mode.                                                                                         |
+| `afterInteractive`  | `void`           | Emitted when the challenge has left interactive mode.                                                                                         |
+| `unsupported`       | `void`           | Emitted when the visitor's browser is not supported by Turnstile.                                                                             |
+| `timeout`           | `void`           | Emitted when an interactive challenge is not solved within the allotted time.                                                                 |
+
+When the token expires, the component automatically resets the widget and emits `resolved(null)`. Use `refreshExpired` to opt into Cloudflare's native refresh handling.
 
 ### Example
 

--- a/projects/ngx-turnstile/README.md
+++ b/projects/ngx-turnstile/README.md
@@ -15,54 +15,109 @@ npm install ngx-turnstile --save
 
 ## Quickstart
 
-To start, import the TurnstileModule in your app module.
+`NgxTurnstileComponent` is a standalone component. Import it directly into any standalone component (or `NgModule`) that needs it:
+
+```typescript
+// app.component.ts
+import { Component } from "@angular/core";
+import { NgxTurnstileComponent } from "ngx-turnstile";
+
+@Component({
+  selector: "my-app",
+  standalone: true,
+  imports: [NgxTurnstileComponent],
+  template: `<ngx-turnstile [siteKey]="siteKey" (resolved)="sendCaptchaResponse($event)" theme="auto" [tabIndex]="0"></ngx-turnstile>`,
+})
+export class MyApp {
+  siteKey = "<YOUR_SITE_KEY>";
+
+  sendCaptchaResponse(captchaResponse: string | null) {
+    console.log(`Resolved captcha with response: ${captchaResponse}`);
+  }
+}
+```
+
+If you use `NgModule`s, you can instead import `NgxTurnstileModule`:
 
 ```typescript
 // app.module.ts
-import { TurnstileModule } from "ngx-turnstile";
+import { NgxTurnstileModule } from "ngx-turnstile";
 import { BrowserModule } from "@angular/platform-browser";
 import { MyApp } from "./app.component.ts";
 
 @NgModule({
   bootstrap: [MyApp],
   declarations: [MyApp],
-  imports: [BrowserModule, TurnstileModule],
+  imports: [BrowserModule, NgxTurnstileModule],
 })
 export class MyAppModule {}
 ```
 
-After that, you are free to use the component anywhere:
+## Usage with @angular/forms
+
+Import both `NgxTurnstileModule` and `NgxTurnstileFormsModule` modules in your app module.
 
 ```typescript
-// app.component.ts
-import { Component } from "@angular/core";
-
-@Component({
-  selector: "my-app",
-  template: `<ngx-turnstile [siteKey]="siteKey" (resolved)="sendCaptchaResponse($event)" theme="auto" [tabIndex]="0"></ngx-turnstile>`,
-})
-export class MyApp {
-  sendCaptchaResponse(captchaResponse: string) {
-    console.log(`Resolved captcha with response: ${captchaResponse}`);
-  }
-}
+import { NgxTurnstileModule, NgxTurnstileFormsModule } from "ngx-turnstile";
 ```
+
+Then import either `FormsModule` or `ReactiveFormsModule` from `@angular/forms` depending on the type of form you want to use.
+
+You can then use the `ngModel`, `formControl` or `formControlName` directives on the component depending on which module you imported from `@angular/forms`.
+
+### Reactive Form Example
+
+```html
+<ngx-turnstile [siteKey]="siteKey" theme="auto" [formControl]="tokenControl"></ngx-turnstile>
+```
+
+### Template Driven Form Example
+
+```html
+<ngx-turnstile [siteKey]="siteKey" theme="light" [(ngModel)]="token"></ngx-turnstile>
+```
+
+The component is read-only, meaning that you should not update the control with a custom value. Updating the control value will reset the component.
 
 ## API
 
-The component supports these options as input:
+### Inputs
 
-- `siteKey`
-- `action`
-- `cData`
-- `theme`
-- `tabIndex`
+The letter cases are adapted to camelCase to facilitate easy migration from `ng-recaptcha`. Each input maps to the corresponding [Cloudflare render parameter](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/widget-configurations/).
 
-These options are well documented in the [Cloudflare Docs](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations). The letter cases are adapted to camelCase to facilitate easy migration from `ng-recaptcha`.
+| Input                 | Type                                          | Default                   | Description                                                                                                                                                                             |
+| --------------------- | --------------------------------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `siteKey`             | `string` (required)                           | —                         | Your widget's sitekey, created when the widget is created.                                                                                                                              |
+| `action`              | `string`                                      | —                         | A customer value to differentiate widgets under the same sitekey (up to 32 chars: alphanumeric, `_`, `-`). Returned upon validation.                                                    |
+| `cData`               | `string`                                      | —                         | A customer payload attached to the challenge (up to 255 chars: alphanumeric, `_`, `-`). Returned upon validation.                                                                       |
+| `theme`               | `'light' \| 'dark' \| 'auto'`                 | `'auto'`                  | Widget theme. `auto` respects the visitor's preference.                                                                                                                                 |
+| `language`            | `string`                                      | `'auto'`                  | `auto`, or an ISO 639-1 code (e.g. `en`) / language-country code (e.g. `en-US`). See [supported languages](https://developers.cloudflare.com/turnstile/reference/supported-languages/). |
+| `tabIndex`            | `number`                                      | `0`                       | The `tabindex` of Turnstile's iframe for accessibility.                                                                                                                                 |
+| `appearance`          | `'always' \| 'execute' \| 'interaction-only'` | `'always'`                | Controls when the widget is visible. See [Appearance modes](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#appearance-modes).                           |
+| `execution`           | `'render' \| 'execute'`                       | `'render'`                | Controls when to obtain the token. See [Execution modes](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#execution-modes).                               |
+| `retry`               | `'auto' \| 'never'`                           | `'auto'`                  | Whether the widget automatically retries to obtain a token on failure.                                                                                                                  |
+| `retryInterval`       | `number`                                      | `8000`                    | When `retry` is `auto`, the time between retry attempts in ms. Positive integer less than `900000`.                                                                                     |
+| `refreshExpired`      | `'auto' \| 'manual' \| 'never'`               | `'auto'`                  | Behavior when the token expires.                                                                                                                                                        |
+| `refreshTimeout`      | `'auto' \| 'manual' \| 'never'`               | `'auto'`                  | Behavior when an interactive challenge times out. Only applies to widgets in Managed mode.                                                                                              |
+| `size`                | `'normal' \| 'flexible' \| 'compact'`         | `'normal'`                | Widget size.                                                                                                                                                                            |
+| `responseField`       | `boolean`                                     | `true`                    | Whether to create a hidden input element containing the response token.                                                                                                                 |
+| `responseFieldName`   | `string`                                      | `'cf-turnstile-response'` | Name of the hidden input element.                                                                                                                                                       |
+| `feedbackEnabled`     | `boolean`                                     | `true`                    | Allows Cloudflare to gather visitor feedback upon widget failure.                                                                                                                       |
+| `offlabelShowPrivacy` | `boolean`                                     | `true`                    | Displays the privacy link for unbranded Turnstile widgets.                                                                                                                              |
+| `offlabelShowHelp`    | `boolean`                                     | `true`                    | Displays the help link for unbranded Turnstile widgets.                                                                                                                                 |
 
-### Events
+### Outputs
 
-- `resolved(response: string)`. Occurs when the CAPTCHA resolution value changed.
+| Output              | Payload          | Description                                                                                                                                   |
+| ------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `resolved`          | `string \| null` | Emitted when the CAPTCHA resolution value changes. Emits `null` when the widget is reset (e.g. on token expiry).                              |
+| `errored`           | `string \| null` | Emitted when the widget returns an [error code](https://developers.cloudflare.com/turnstile/troubleshooting/client-side-errors/#error-codes). |
+| `beforeInteractive` | `void`           | Emitted before the challenge enters interactive mode.                                                                                         |
+| `afterInteractive`  | `void`           | Emitted when the challenge has left interactive mode.                                                                                         |
+| `unsupported`       | `void`           | Emitted when the visitor's browser is not supported by Turnstile.                                                                             |
+| `timeout`           | `void`           | Emitted when an interactive challenge is not solved within the allotted time.                                                                 |
+
+When the token expires, the component automatically resets the widget and emits `resolved(null)`. Use `refreshExpired` to opt into Cloudflare's native refresh handling.
 
 ### Example
 

--- a/projects/ngx-turnstile/src/lib/interfaces/turnstile-options.ts
+++ b/projects/ngx-turnstile/src/lib/interfaces/turnstile-options.ts
@@ -5,10 +5,23 @@ export interface TurnstileOptions {
   callback?: (token: string) => void;
   'error-callback'?: (errorCode: string) => boolean;
   'expired-callback'?: () => void;
+  'before-interactive-callback'?: () => void;
+  'after-interactive-callback'?: () => void;
+  'unsupported-callback'?: () => void;
+  'timeout-callback'?: () => void;
   theme?: 'light' | 'dark' | 'auto';
   language?: string;
   tabindex?: number;
   appearance?: 'always' | 'execute' | 'interaction-only';
+  execution?: 'render' | 'execute';
   retry?: 'never' | 'auto';
+  'retry-interval'?: number;
+  'refresh-expired'?: 'auto' | 'manual' | 'never';
+  'refresh-timeout'?: 'auto' | 'manual' | 'never';
   size?: 'normal' | 'flexible' | 'compact';
+  'response-field'?: boolean;
+  'response-field-name'?: string;
+  'feedback-enabled'?: boolean;
+  'offlabel-show-privacy'?: boolean;
+  'offlabel-show-help'?: boolean;
 }

--- a/projects/ngx-turnstile/src/lib/ngx-turnstile.component.spec.ts
+++ b/projects/ngx-turnstile/src/lib/ngx-turnstile.component.spec.ts
@@ -1,12 +1,26 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { NgxTurnstileComponent } from './ngx-turnstile.component';
+import { TurnstileOptions } from './interfaces/turnstile-options';
 
 describe('NgxTurnstileComponent', () => {
   let component: NgxTurnstileComponent;
   let fixture: ComponentFixture<NgxTurnstileComponent>;
+  let renderedOptions: TurnstileOptions;
 
   beforeEach(async () => {
+    // Stub the Turnstile script global before the component is constructed and
+    // capture the options passed to turnstile.render().
+    window.turnstile = {
+      render: (_el: string | HTMLElement, options: TurnstileOptions) => {
+        renderedOptions = options;
+        return 'widget-id';
+      },
+      reset: () => {},
+      getResponse: () => undefined,
+      remove: () => {},
+    };
+
     await TestBed.configureTestingModule({
       imports: [NgxTurnstileComponent],
     }).compileComponents();
@@ -16,7 +30,69 @@ describe('NgxTurnstileComponent', () => {
     fixture.detectChanges();
   });
 
+  /** Render with the currently-set inputs, pretending the script is loaded. */
+  function render(): void {
+    component.scriptLoaded.set(true);
+    component.createWidget();
+  }
+
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('maps camelCase inputs to Cloudflare wire keys', () => {
+    component.siteKey = 'test-key';
+    component.execution = 'execute';
+    component.retryInterval = 5000;
+    component.refreshExpired = 'manual';
+    component.refreshTimeout = 'never';
+    component.responseField = false;
+    component.responseFieldName = 'my-token';
+    component.feedbackEnabled = false;
+    component.offlabelShowPrivacy = false;
+    component.offlabelShowHelp = false;
+
+    render();
+
+    expect(renderedOptions.sitekey).toBe('test-key');
+    expect(renderedOptions.execution).toBe('execute');
+    expect(renderedOptions['retry-interval']).toBe(5000);
+    expect(renderedOptions['refresh-expired']).toBe('manual');
+    expect(renderedOptions['refresh-timeout']).toBe('never');
+    expect(renderedOptions['response-field']).toBe(false);
+    expect(renderedOptions['response-field-name']).toBe('my-token');
+    expect(renderedOptions['feedback-enabled']).toBe(false);
+    expect(renderedOptions['offlabel-show-privacy']).toBe(false);
+    expect(renderedOptions['offlabel-show-help']).toBe(false);
+  });
+
+  it('omits optional parameters that are not set', () => {
+    component.siteKey = 'test-key';
+
+    render();
+
+    expect('execution' in renderedOptions).toBe(false);
+    expect('retry-interval' in renderedOptions).toBe(false);
+    expect('refresh-expired' in renderedOptions).toBe(false);
+    expect('response-field' in renderedOptions).toBe(false);
+    expect('feedback-enabled' in renderedOptions).toBe(false);
+  });
+
+  it('emits lifecycle outputs when their callbacks fire', () => {
+    component.siteKey = 'test-key';
+    render();
+
+    const emitted: string[] = [];
+    component.beforeInteractive.subscribe(() => emitted.push('before'));
+    component.afterInteractive.subscribe(() => emitted.push('after'));
+    component.unsupported.subscribe(() => emitted.push('unsupported'));
+    component.timeout.subscribe(() => emitted.push('timeout'));
+
+    renderedOptions['before-interactive-callback']!();
+    renderedOptions['after-interactive-callback']!();
+    renderedOptions['unsupported-callback']!();
+    renderedOptions['timeout-callback']!();
+
+    expect(emitted).toEqual(['before', 'after', 'unsupported', 'timeout']);
   });
 });

--- a/projects/ngx-turnstile/src/lib/ngx-turnstile.component.ts
+++ b/projects/ngx-turnstile/src/lib/ngx-turnstile.component.ts
@@ -57,11 +57,24 @@ export class NgxTurnstileComponent implements OnDestroy {
   @Input() version: SupportedVersion = '0';
   @Input() tabIndex?: number;
   @Input() appearance?: 'always' | 'execute' | 'interaction-only' = 'always';
+  @Input() execution?: 'render' | 'execute';
   @Input() retry?: 'never' | 'auto' = 'auto';
+  @Input() retryInterval?: number;
+  @Input() refreshExpired?: 'auto' | 'manual' | 'never';
+  @Input() refreshTimeout?: 'auto' | 'manual' | 'never';
   @Input() size?: 'normal' | 'flexible' | 'compact' = 'normal';
+  @Input() responseField?: boolean;
+  @Input() responseFieldName?: string;
+  @Input() feedbackEnabled?: boolean;
+  @Input() offlabelShowPrivacy?: boolean;
+  @Input() offlabelShowHelp?: boolean;
 
   @Output() resolved = new EventEmitter<string | null>();
   @Output() errored = new EventEmitter<string | null>();
+  @Output() beforeInteractive = new EventEmitter<void>();
+  @Output() afterInteractive = new EventEmitter<void>();
+  @Output() unsupported = new EventEmitter<void>();
+  @Output() timeout = new EventEmitter<void>();
 
   private widgetId = signal<string | null | undefined>(undefined);
 
@@ -169,7 +182,49 @@ export class NgxTurnstileComponent implements OnDestroy {
       'expired-callback': () => {
         this.zone.run(() => this.reset());
       },
+      'before-interactive-callback': () => {
+        this.zone.run(() => this.beforeInteractive.emit());
+      },
+      'after-interactive-callback': () => {
+        this.zone.run(() => this.afterInteractive.emit());
+      },
+      'unsupported-callback': () => {
+        this.zone.run(() => this.unsupported.emit());
+      },
+      'timeout-callback': () => {
+        this.zone.run(() => this.timeout.emit());
+      },
     };
+
+    // Only forward optional parameters when set, so we never override
+    // Cloudflare's defaults with an explicit `undefined`.
+    if (this.execution !== undefined) {
+      turnstileOptions.execution = this.execution;
+    }
+    if (this.retryInterval !== undefined) {
+      turnstileOptions['retry-interval'] = this.retryInterval;
+    }
+    if (this.refreshExpired !== undefined) {
+      turnstileOptions['refresh-expired'] = this.refreshExpired;
+    }
+    if (this.refreshTimeout !== undefined) {
+      turnstileOptions['refresh-timeout'] = this.refreshTimeout;
+    }
+    if (this.responseField !== undefined) {
+      turnstileOptions['response-field'] = this.responseField;
+    }
+    if (this.responseFieldName !== undefined) {
+      turnstileOptions['response-field-name'] = this.responseFieldName;
+    }
+    if (this.feedbackEnabled !== undefined) {
+      turnstileOptions['feedback-enabled'] = this.feedbackEnabled;
+    }
+    if (this.offlabelShowPrivacy !== undefined) {
+      turnstileOptions['offlabel-show-privacy'] = this.offlabelShowPrivacy;
+    }
+    if (this.offlabelShowHelp !== undefined) {
+      turnstileOptions['offlabel-show-help'] = this.offlabelShowHelp;
+    }
 
     // Remove any existing widget so re-rendering doesn't create duplicates.
     this.remove();


### PR DESCRIPTION
## Summary

Brings the Angular `ngx-turnstile` widget up to date with Cloudflare's current [Turnstile widget-configurations documentation](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/widget-configurations/) (last updated 2026-06-28). Every documented render parameter and lifecycle callback is now exposed, and the README reflects the additions and the already-shipped standalone-component API.

## New `@Input()`s

Added (camelCase, consistent with the existing `siteKey`/`cData`/`tabIndex` inputs), each mapped to its Cloudflare wire key:

| Input | Wire key |
| --- | --- |
| `execution` | `execution` |
| `retryInterval` | `retry-interval` |
| `refreshExpired` | `refresh-expired` |
| `refreshTimeout` | `refresh-timeout` |
| `responseField` | `response-field` |
| `responseFieldName` | `response-field-name` |
| `feedbackEnabled` | `feedback-enabled` |
| `offlabelShowPrivacy` | `offlabel-show-privacy` |
| `offlabelShowHelp` | `offlabel-show-help` |

Optional params are only forwarded to `turnstile.render()` when set, so Cloudflare defaults are never overridden with an explicit `undefined`.

## New `@Output()` events

`beforeInteractive`, `afterInteractive`, `unsupported`, `timeout` — each an `EventEmitter<void>`, wired through `NgZone` like the existing `resolved`/`errored` outputs.

## README

- Full **Inputs** and **Outputs** tables (name, type, default, description) sourced from the current docs.
- Docs link updated to the new `widget-configurations/` page.
- Quickstart modernized to standalone-component usage (import `NgxTurnstileComponent` directly; `NgxTurnstileModule` still documented for `NgModule` users).

## Backwards compatibility

No breaking changes. Existing inputs/outputs are untouched, and the current expiry behavior (auto-reset + `resolved(null)`) is preserved. `refreshExpired` lets consumers opt into Cloudflare's native refresh handling.

## Testing

- `ng build ngx-turnstile` ✓
- `ng test ngx-turnstile` ✓ (added specs for new input mapping, omit-when-unset, and output emission)
- `ng lint ngx-turnstile` ✓
- `prettier --check .` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)